### PR TITLE
Fix: Sanitize hyphenated MCP tool names for Python attribute access

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
   "Programming Language :: Python :: 3 :: Only",
 ]
 
-dependencies = ["fastcore", "httpx", "toolslm>=0.3.34""]
+dependencies = ["fastcore", "httpx", "toolslm>=0.3.34"]
 
 [project.optional-dependencies]
 dev = [ "fastship", "build", "twine", ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
   "Programming Language :: Python :: 3 :: Only",
 ]
 
-dependencies = ["fastcore", "httpx"]
+dependencies = ["fastcore", "httpx", "toolslm>=0.3.34""]
 
 [project.optional-dependencies]
 dev = [ "fastship", "build", "twine", ]

--- a/solvemcp/client.py
+++ b/solvemcp/client.py
@@ -7,11 +7,11 @@ import httpx
 from fastcore.basics import AttrDict
 from fastcore.meta import delegates
 from fastcore.utils import *
-from toolslm.funccall import mk_tool
+from toolslm.funccall import _py_nm, mk_tool
 
 from .transports import (LegacySSETransport, MCPError, MCPRemoteError, MCPTimeout, MCPTransport,
-                         MCPTransportError, StdioTransport, StreamableHTTPTransport, _as_list,
-                         _is_notif, _is_req, _is_resp, _now)
+    MCPTransportError, StdioTransport, StreamableHTTPTransport, _as_list,
+    _is_notif, _is_req, _is_resp, _now)
 
 
 def _rpc_msg(method:str, *, id_:Any=None, params:dict|None=None):
@@ -32,8 +32,8 @@ class MCPClient:
     supported_protocol_versions = ('2025-06-18', '2025-03-26', '2024-11-05')
 
     def __init__(self, transport:MCPTransport, *, client_name:str='solvemcp', client_version:str='0.1.0',
-                 capabilities:dict|None=None, protocol_version:str|None=None, init_timeout:float=20.0,
-                 request_timeout:float=30.0, auto_initialize:bool=True, auto_tools:bool=True):
+        capabilities:dict|None=None, protocol_version:str|None=None, init_timeout:float=20.0,
+        request_timeout:float=30.0, auto_initialize:bool=True, auto_tools:bool=True):
         self.t = transport
         self.client_info = dict(name=client_name, version=client_version)
         self.capabilities = capabilities or {}
@@ -106,7 +106,7 @@ class MCPClient:
     def initialize(self, *, timeout:float|None=None, capabilities:dict|None=None, protocol_version:str|None=None):
         if protocol_version: self.protocol_version = protocol_version
         init_params = dict(protocolVersion=self.protocol_version, capabilities=capabilities or self.capabilities,
-                           clientInfo=self.client_info)
+            clientInfo=self.client_info)
 
         last_err = None
         versions = (self.protocol_version,) + tuple(v for v in self.supported_protocol_versions if v != self.protocol_version)
@@ -281,9 +281,10 @@ class MCPClient:
 
         for t in self.tools.values():
             name = t.name
-            if not name or not name.isidentifier(): continue
-            if hasattr(self, name): continue
-            setattr(self, name, mk_tool(self.call_tool, t))
+            if not name: continue
+            py_name = _py_nm(name)
+            if not py_name or hasattr(self, py_name): continue
+            setattr(self, py_name, mk_tool(self.call_tool, t))
         return self.tools
 
     def call_tool(self, name:str, **kwargs)->AttrDict: return self.rpc('tools/call', dict(name=name, arguments=kwargs))
@@ -293,7 +294,7 @@ class MCPClient:
 
     def __dir__(self):
         base = set(super().__dir__())
-        tools = set(getattr(self, 'tools', {}).keys())
+        tools = {_py_nm(name) for name in getattr(self, 'tools', {}).keys()}
         return sorted(base | tools)
 
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from fake_payloads import initialize_result, listing_notification, rpc_error, rpc_result, tools_list_result, tool_call_result
 from solvemcp import *
 
+test_eq.__test__ = False
+
 
 # --- SSE parsing
 sample = 'data: {"a":1}\n\ndata: {"b":2}\n\n'
@@ -82,8 +84,7 @@ def _run_http_fake_server():
                 resp = tools_list_result(rid)
                 events = [
                     'data: ' + json.dumps(notif, separators=(',', ':')) + '\n\n',
-                    'data: ' + json.dumps(resp, separators=(',', ':')) + '\n\n',
-                ]
+                    'data: ' + json.dumps(resp, separators=(',', ':')) + '\n\n']
                 self._send_sse(events)
                 return
 
@@ -139,3 +140,75 @@ if __name__ == '__main__':
             test_eq('notifications/message' in methods, True)
     finally: shutdown()
     print('ok')
+
+
+def test_refresh_tools_attaches_sanitized_attr_for_hyphenated_tool():
+    calls = []
+    schema = dict(type='object', properties={'text': dict(type='string', description='text')}, required=['text'])
+    tools = [dict(name='codex-reply', description='Reply to Codex', inputSchema=schema)]
+
+    def rpc(method, params=None, timeout=None):
+        calls.append((method, params))
+        if method == 'tools/list': return dict(tools=tools)
+        if method == 'tools/call': return dict(content=[dict(type='text', text=params['arguments']['text'])])
+        raise AssertionError(f'unexpected method: {method}')
+
+    c = object.__new__(MCPClient)
+    c.rpc = rpc
+
+    MCPClient.refresh_tools(c)
+
+    test_eq('codex-reply' in c.tools, True)
+    test_eq(hasattr(c, 'codex_reply'), True)
+
+    c.codex_reply(text='hi')
+
+    test_eq(calls[-1][0], 'tools/call')
+    test_eq(calls[-1][1]['name'], 'codex-reply')
+    test_eq(calls[-1][1]['arguments'], {'text': 'hi'})
+
+
+def test_dir_lists_sanitized_tool_names():
+    schema = dict(type='object', properties={'text': dict(type='string', description='text')}, required=['text'])
+    tools = [dict(name='codex-reply', description='Reply to Codex', inputSchema=schema)]
+
+    def rpc(method, params=None, timeout=None):
+        if method == 'tools/list': return dict(tools=tools)
+        raise AssertionError(f'unexpected method: {method}')
+
+    c = object.__new__(MCPClient)
+    c.rpc = rpc
+
+    MCPClient.refresh_tools(c)
+
+    names = dir(c)
+
+    test_eq('codex_reply' in names, True)
+    test_eq('codex-reply' in names, False)
+
+
+def test_refresh_tools_uses_py_nm_rules_for_keywords_and_leading_digits():
+    calls = []
+    schema = dict(type='object', properties={'text': dict(type='string', description='text')}, required=['text'])
+    tools = [dict(name='class', description='Python keyword name', inputSchema=schema),
+        dict(name='1start', description='Leading digit name', inputSchema=schema)]
+
+    def rpc(method, params=None, timeout=None):
+        calls.append((method, params))
+        if method == 'tools/list': return dict(tools=tools)
+        if method == 'tools/call': return dict(content=[dict(type='text', text=params['name'])])
+        raise AssertionError(f'unexpected method: {method}')
+
+    c = object.__new__(MCPClient)
+    c.rpc = rpc
+
+    MCPClient.refresh_tools(c)
+
+    test_eq(hasattr(c, 'class_'), True)
+    test_eq(hasattr(c, '_1start'), True)
+
+    c.class_(text='first')
+    test_eq(calls[-1][1]['name'], 'class')
+
+    c._1start(text='second')
+    test_eq(calls[-1][1]['name'], '1start')


### PR DESCRIPTION
MCP tools with hyphenated names (like `codex-reply`) couldn't be accessed as Python attributes since hyphens aren't valid in identifiers.

**Changes:**
- Use `toolslm._py_nm()` to convert tool names to valid Python identifiers (`codex-reply` → `codex_reply`)
- Original MCP names preserved in `self.tools` and used for RPC dispatch
- Update `__dir__` to return sanitized names for tab-completion

**Also handles:**
- Python keywords (`class` → `class_`)
- Leading digits (`1start` → `_1start`)

This adds `toolslm` as a dep and requires this PR to be merged and released before this one can be: https://github.com/AnswerDotAI/toolslm/pull/81